### PR TITLE
FoLiA profiler

### DIFF
--- a/src/main/java/eu/clarin/switchboard/profiler/api/Profile.java
+++ b/src/main/java/eu/clarin/switchboard/profiler/api/Profile.java
@@ -197,6 +197,16 @@ public class Profile implements Comparable<Profile> {
             return this;
         }
 
+        //allow some introspection during building
+        public boolean hasFeature(String featureKey) {
+            return features.containsKey(featureKey);
+        }
+
+        //allow some introspection during building
+        public String getFeature(String featureKey) {
+            return features.get(featureKey);
+        }
+
         public Profile build() {
             return new Profile(confidence, mediaType, features);
         }

--- a/src/main/java/eu/clarin/switchboard/profiler/api/Profile.java
+++ b/src/main/java/eu/clarin/switchboard/profiler/api/Profile.java
@@ -55,6 +55,10 @@ public class Profile implements Comparable<Profile> {
         return features;
     }
 
+    public boolean hasFeature(String featureKey) {
+        return features.containsKey(featureKey);
+    }
+
     public String getFeature(String featureKey) {
         return features.get(featureKey);
     }

--- a/src/main/java/eu/clarin/switchboard/profiler/xml/FoliaProfiler.java
+++ b/src/main/java/eu/clarin/switchboard/profiler/xml/FoliaProfiler.java
@@ -75,7 +75,7 @@ public class FoliaProfiler implements Profiler {
                     if (elementName.equals(XMLNAME_FOLIA_ROOT)) {
                         profileBuilder.mediaType(MEDIATYPE_FOLIA);
                         Attribute attribute = element.getAttributeByName(new QName(XMLNAME_VERSION));
-                        if (attribute != null) {
+                        if (attribute == null) {
                             throw new ProfilingException("FoLiA document has no version attribute!");
                         }
                         profileBuilder.feature(FEATURE_VERSION, attribute.getValue());
@@ -109,9 +109,10 @@ public class FoliaProfiler implements Profiler {
                     } else if ((isInDeclarations) && elementName.endsWith("-annotation")) {
                         Attribute attribute = element.getAttributeByName(new QName(XMLNAME_SET));
 
+
                         //the feature name is exactly the same as the element name in the declaration, so you get
                         //features like: token-annotation, lemma-annotation, text-annotation, dependency-annotation, etc..
-                        String featureName = attribute.getName().getLocalPart().toLowerCase();
+                        String featureName = elementName;
 
                         //the feature value is a comma separated list of sets (as there can be multiple)
                         //or, in case an annotation layer is not associated with any set, the value is empty.
@@ -124,10 +125,13 @@ public class FoliaProfiler implements Profiler {
                                 if (!value.isEmpty()) {
                                     profileBuilder.feature(featureName, value.concat(",").concat(attribute.getValue()));
                                 } else {
-                                    profileBuilder.feature(featureName, "");
+                                    profileBuilder.feature(featureName, attribute.getValue());
                                 }
+                            } else {
+                                profileBuilder.feature(featureName, attribute.getValue());
                             }
                         }
+
 
                         //FoLiA >v2 holds more information (list of annotators per annotation type/set), but
                         //those are currently not propagated to the profiler yet (probably overkill)
@@ -169,7 +173,7 @@ public class FoliaProfiler implements Profiler {
                             if (metaFieldValue.length() == 2) {
                                 //assume iso-639-1
                                 String lang = LanguageCode.iso639_1to639_3(metaFieldValue);
-                                profileBuilder.feature(FEATURE_LANGUAGE, metaFieldValue);
+                                profileBuilder.feature(FEATURE_LANGUAGE, lang);
                             } else if (metaFieldValue.length() == 3) {
                                 //assume iso-639-3
                                 profileBuilder.feature(FEATURE_LANGUAGE, metaFieldValue);

--- a/src/main/java/eu/clarin/switchboard/profiler/xml/FoliaProfiler.java
+++ b/src/main/java/eu/clarin/switchboard/profiler/xml/FoliaProfiler.java
@@ -1,0 +1,197 @@
+/*
+ * Adds support for profiling FoLiA XML
+ * by Maarten van Gompel (proycon) - proycon@anaproy.nl
+ *
+ */
+
+package eu.clarin.switchboard.profiler.xml;
+
+import eu.clarin.switchboard.profiler.api.*;
+import eu.clarin.switchboard.profiler.utils.LanguageCode;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.Attribute;
+import javax.xml.stream.events.StartElement;
+import javax.xml.stream.events.XMLEvent;
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+
+public class FoliaProfiler implements Profiler {
+    public final static String XMLNAME_FOLIA_ROOT = "FoLiA";
+
+    public final static String NAMESPACE_FOLIA = "http://ilk.uvt.nl/folia";
+    public final static String MEDIATYPE_FOLIA = "application/folia+xml";
+
+    public static final String FEATURE_VERSION = "version";
+    public static final String FEATURE_PROVENANCE = "provenance"; //comma seperated list of tools that processed this document
+    public static final String FEATURE_LANGUAGE = "language";
+
+    private final static String XMLNAME_VERSION = "version";
+    private final static String XMLNAME_METADATA = "metadata";
+    private final static String XMLNAME_DECLARATIONS = "annotations";
+    private final static String XMLNAME_PROVENANCE = "provenance";
+    private final static String XMLNAME_METAFIELD = "meta";
+    private final static String XMLNAME_PROCESSOR = "processor";
+
+    private final static String XMLNAME_SET = "set";
+
+
+    XMLInputFactory xmlInputFactory;
+
+    public FoliaProfiler() {
+        this(XMLInputFactory.newInstance());
+    }
+
+    public FoliaProfiler(XMLInputFactory factory) {
+        this.xmlInputFactory = factory;
+    }
+
+    @Override
+    public List<Profile> profile(File file) throws IOException, ProfilingException {
+        XMLEventReader xmlReader = XmlUtils.newReader(xmlInputFactory, file);
+
+        Profile.Builder profileBuilder = Profile.builder().certain();
+        try {
+            boolean isInDocument = false;
+            boolean isInMetadata = false;
+            boolean isInProvenance = false;
+            boolean isInDeclarations = false;
+            boolean hasMetadata = false;
+            boolean hasDeclarations = false;
+            boolean hasProvenance = false;
+            boolean hasErrors = false;
+            String processors_flattened = ""; //comma separated list of names of tools through which this document has gone during processing (the original is a full provenance tree structure and contains a lot of details, this is a simplified flattened representation
+            String inMetaField = null;
+            String metaFieldValue = "";
+            while (xmlReader.hasNext()) {
+                XMLEvent event = xmlReader.nextEvent();
+                if (event.isStartElement()) {
+                    StartElement element = event.asStartElement();
+                    String elementName = element.getName().getLocalPart();
+                    if (elementName.equals(XMLNAME_FOLIA_ROOT)) {
+                        profileBuilder.mediaType(MEDIATYPE_FOLIA);
+                        Attribute attribute = element.getAttributeByName(new QName(XMLNAME_VERSION));
+                        if (attribute != null) {
+                            throw new ProfilingException("FoLiA document has no version attribute!");
+                        }
+                        profileBuilder.feature(FEATURE_VERSION, attribute.getValue());
+                        hasErrors = true;
+                        isInDocument = true;
+                        //TODO LATER: check namespace? [low priority]
+                    } else if (elementName.equals(XMLNAME_METADATA) && isInDocument)  {
+                        isInMetadata = true;
+                        hasMetadata = true;
+                        Attribute srcAttribute = element.getAttributeByName(new QName("src"));
+                        if (srcAttribute != null) {
+                            //links to an external metadata file (e.g. CMDI): URL (or local path)
+                            profileBuilder.feature("externalMetadata", srcAttribute.getValue());
+                            Attribute typeAttribute = element.getAttributeByName(new QName("type"));
+                            if (typeAttribute != null) {
+                                //specified the type of the external metadata (e.g. cmdi)
+                                profileBuilder.feature("externalMetadataType", typeAttribute.getValue());
+                            }
+                            //TODO LATER: if a FoLiA document uses an external metadata file,
+                            // rather than an inline native metadata
+                            // then it might need to be retrieved and parsed to get all the metadata!
+                        }
+                    } else if (elementName.equals(XMLNAME_DECLARATIONS) && isInMetadata)  {
+                        isInDeclarations = true;
+                    } else if (elementName.equals(XMLNAME_PROVENANCE) && isInMetadata)  {
+                        isInProvenance = true;
+                        hasProvenance = true;
+                    } else if (!isInDocument) {
+                        //invalid root tag!
+                        throw new ProfilingException("Invalid root tag for FoLiA document!");
+                    } else if ((isInDeclarations) && elementName.endsWith("-annotation")) {
+                        Attribute attribute = element.getAttributeByName(new QName(XMLNAME_SET));
+
+                        //the feature name is exactly the same as the element name in the declaration, so you get
+                        //features like: token-annotation, lemma-annotation, text-annotation, dependency-annotation, etc..
+                        String featureName = attribute.getName().getLocalPart().toLowerCase();
+
+                        //the feature value is a comma separated list of sets (as there can be multiple)
+                        //or, in case an annotation layer is not associated with any set, the value is empty.
+                        //(sets are usually URLs to set definitions)
+                        if (attribute == null) {
+                            profileBuilder.feature(featureName, "");
+                        } else {
+                            if (profileBuilder.hasFeature(featureName)) {
+                                String value = profileBuilder.getFeature(featureName);
+                                if (!value.isEmpty()) {
+                                    profileBuilder.feature(featureName, value.concat(",").concat(attribute.getValue()));
+                                } else {
+                                    profileBuilder.feature(featureName, "");
+                                }
+                            }
+                        }
+
+                        //FoLiA >v2 holds more information (list of annotators per annotation type/set), but
+                        //those are currently not propagated to the profiler yet (probably overkill)
+
+                    } else if ((isInMetadata) && (!isInProvenance) && elementName.equals(XMLNAME_METAFIELD)) {
+                        //make available any arbitrary metadata from the FoLiA document to the profiler
+                        //(note: this is not a controlled vocabulary!)
+                        Attribute attribute = element.getAttributeByName(new QName("id"));
+                        if (attribute != null) {
+                            inMetaField = attribute.getValue();
+                            metaFieldValue = "";
+                        }
+                    } else if (isInProvenance && elementName.equals(XMLNAME_PROCESSOR)) {
+                        Attribute attribute = element.getAttributeByName(new QName("name"));
+                        if (attribute != null) {
+                            if (!processors_flattened.isEmpty()) {
+                                processors_flattened += ",";
+                            }
+                            processors_flattened += attribute.getValue();
+                        }
+                    }
+                } else if (inMetaField != null && event.isCharacters()) {
+                    metaFieldValue += event.asCharacters().getData();
+                } else if (event.isEndElement()) {
+                    String elementName = event.asEndElement().getName().getLocalPart();
+                    if (elementName.equals(XMLNAME_METADATA)) {
+                        //prevent parsing the entire document (may be large!)
+                        //just stop after metadata header
+                        isInMetadata = false;
+                        break;
+                    } else if (elementName.equals(XMLNAME_DECLARATIONS)) {
+                        isInDeclarations = false;
+                    } else if (elementName.equals(XMLNAME_PROVENANCE)) {
+                        isInProvenance = false;
+                    } else if (elementName.equals(XMLNAME_METAFIELD) && (inMetaField != null)) {
+                        if (inMetaField.equals("language") || inMetaField.equals("lang")) {
+                            //this is a controlled vocabulary for the profiler, but not for FoLiA
+                            //we'll do some guesses:
+                            if (metaFieldValue.length() == 2) {
+                                //assume iso-639-1
+                                String lang = LanguageCode.iso639_1to639_3(metaFieldValue);
+                                profileBuilder.feature(FEATURE_LANGUAGE, metaFieldValue);
+                            } else if (metaFieldValue.length() == 3) {
+                                //assume iso-639-3
+                                profileBuilder.feature(FEATURE_LANGUAGE, metaFieldValue);
+                            } else {
+                                //don't add the feature because we're not sure what it represents
+                            }
+                        } else {
+                            profileBuilder.feature(inMetaField, metaFieldValue);
+                        }
+                        inMetaField = null;
+                    }
+                }
+            }
+            if (hasProvenance && !processors_flattened.isEmpty()) {
+                profileBuilder.feature(FEATURE_PROVENANCE, processors_flattened);
+            }
+        } catch (XMLStreamException ex) {
+            throw new ProfilingException("xml stream error", ex);
+        }
+
+
+        return Collections.singletonList(profileBuilder.build());
+    }
+
+}

--- a/src/main/java/eu/clarin/switchboard/profiler/xml/XmlProfiler.java
+++ b/src/main/java/eu/clarin/switchboard/profiler/xml/XmlProfiler.java
@@ -24,7 +24,7 @@ public class XmlProfiler implements Profiler {
     public static final String FEATURE_SCHEMA_SCHEMATRON = "schemaSchematron";
 
     public static final Map<String, String> root2mediaType = ImmutableMap.<String, String>builder()
-            .put("FoLiA", "text/folia+xml")
+            .put("FoLiA", "application/folia+xml")
             .put("maf", "text/maf+xml")
             .put("folker-transcription", "application/xml;format-variant=folker-fln")
             .put("basic-transcription", "application/xml;format-variant=exmaralda-exb")
@@ -59,6 +59,9 @@ public class XmlProfiler implements Profiler {
         if (TcfProfiler.XMLNAME_TCF_ROOT.equals(xmlFeatures.rootName.getLocalPart())) {
             TcfProfiler tcfProfiler = new TcfProfiler(xmlInputFactory);
             return tcfProfiler.profile(file);
+        } else if (FoliaProfiler.XMLNAME_FOLIA_ROOT.equals(xmlFeatures.rootName.getLocalPart())) {
+            FoliaProfiler foliaProfiler = new FoliaProfiler(xmlInputFactory);
+            return foliaProfiler.profile(file);
         } else {
             TeiProfiler teiProfiler = new TeiProfiler(xmlInputFactory);
             if (teiProfiler.isTEIRoot(xmlFeatures.rootName.getLocalPart())) {

--- a/src/test/java/eu/clarin/switchboard/profiler/ProfileAllFilesTest.java
+++ b/src/test/java/eu/clarin/switchboard/profiler/ProfileAllFilesTest.java
@@ -34,8 +34,36 @@ public class ProfileAllFilesTest {
 
             // .put("exmaralda/", Profile.builder().mediaType("application/").build())
 
-            .put("folia/folia-WR-P-E-J-0000000000.folia.xml", Profile.builder().certain().mediaType("application/folia+xml").language("nld").build())
-            .put("folia/folia-arabic.folia.xml", Profile.builder().certain().mediaType("application/folia+xml").language("ara").build())
+            .put("folia/folia-WR-P-E-J-0000000000.folia.xml", Profile.builder().certain()
+                    .mediaType("application/folia+xml")
+                    .feature("version","0.8.0")
+                    .feature("externalMetadata","WR-P-E-J-0000000000.cmdi")
+                    .feature("externalMetadataType","imdi") //well, this is clearly wrong since a CMDI file is references but it's what the original document says, so we test against it..
+                    .feature("token-annotation","")
+                    .feature("pos-annotation","hdl:1839/00-SCHM-0000-0000-000B-9,http://ilk.uvt.nl/folia/sets/frog-mbpos-cgn" )
+                    .feature("lemma-annotation","hdl:1839/00-SCHM-0000-0000-000E-3,http://ilk.uvt.nl/folia/sets/frog-mblem-nl")
+                    .feature("morphological-annotation","http://ilk.uvt.nl/folia/sets/frog-mbma-nl" )
+                    .feature("entity-annotation","hdl:1839/00-SCHM-0000-0000-000D-5")
+                    //.language("und") //language is undefined because it should be in the external metadata (which is not parsed)
+                    .build())
+
+            .put("folia/folia-arabic.folia.xml", Profile.builder().certain()
+                    .mediaType("application/folia+xml")
+                    .feature("version","2.2.1")
+                    .language("ara")
+                    .feature("provenance","proycon,foliavalidator,foliapy")
+                    .feature("token-annotation","")
+                    .feature("division-annotation","")
+                    .feature("sentence-annotation","")
+                    .feature("paragraph-annotation","")
+                    .feature("head-annotation","")
+                    .feature("phonological-annotation","adhoc")
+                    .feature("morphological-annotation","adhoc")
+                    .feature("pos-annotation","adhoc")
+                    .feature("text-annotation","https://raw.githubusercontent.com/proycon/folia/master/setdefinitions/text.foliaset.ttl")
+                    .feature("entity-annotation","https://raw.githubusercontent.com/proycon/folia/master/setdefinitions/namedentities.foliaset.xml")
+                    .feature("phon-annotation","https://raw.githubusercontent.com/proycon/folia/master/setdefinitions/phon.foliaset.ttl")
+                    .feature("direction","rtl").build())
 
             // .put("folker/", Profile.builder().mediaType("application/").build())
 

--- a/src/test/java/eu/clarin/switchboard/profiler/ProfileAllFilesTest.java
+++ b/src/test/java/eu/clarin/switchboard/profiler/ProfileAllFilesTest.java
@@ -18,8 +18,8 @@ import java.util.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class ProfileAllTestFiles {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ProfileAllTestFiles.class);
+public class ProfileAllFilesTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProfileAllFilesTest.class);
 
     static final String RESOURCES_ROOT_PATH = "./src/test/resources/";
 
@@ -121,7 +121,7 @@ public class ProfileAllTestFiles {
 
     DefaultProfiler profiler = new DefaultProfiler();
 
-    public ProfileAllTestFiles() throws TikaException, IOException, SAXException {
+    public ProfileAllFilesTest() throws TikaException, IOException, SAXException {
     }
 
     @Test

--- a/src/test/java/eu/clarin/switchboard/profiler/ProfileAllTestFiles.java
+++ b/src/test/java/eu/clarin/switchboard/profiler/ProfileAllTestFiles.java
@@ -34,7 +34,8 @@ public class ProfileAllTestFiles {
 
             // .put("exmaralda/", Profile.builder().mediaType("application/").build())
 
-            .put("folia/folia-WR-P-E-J-0000000000.folia.xml", Profile.builder().certain().mediaType("text/folia+xml").language("nld").build())
+            .put("folia/folia-WR-P-E-J-0000000000.folia.xml", Profile.builder().certain().mediaType("application/folia+xml").language("nld").build())
+            .put("folia/folia-arabic.folia.xml", Profile.builder().certain().mediaType("application/folia+xml").language("ara").build())
 
             // .put("folker/", Profile.builder().mediaType("application/").build())
 

--- a/src/test/java/eu/clarin/switchboard/profiler/api/ProfileTest.java
+++ b/src/test/java/eu/clarin/switchboard/profiler/api/ProfileTest.java
@@ -21,6 +21,7 @@ public class ProfileTest {
         assertTrue(newProfile("application/xml").isXmlMediaType());
         assertTrue(newProfile("application/tei+xml").isXmlMediaType());
         assertTrue(newProfile("application/tei+xml;format-variant=whatever").isXmlMediaType());
+        assertTrue(newProfile("application/folia+xml").isXmlMediaType());
         assertTrue(newProfile("text/xml+imaginary;parameter=unknown").isXmlMediaType());
         assertTrue(newProfile("text/prs.xml+imaginary;parameter=unknown").isXmlMediaType());
         assertTrue(newProfile("text/prs.xmlasd+xml;parameter=unknown").isXmlMediaType());

--- a/src/test/resources/folia/folia-arabic.folia.xml
+++ b/src/test/resources/folia/folia-arabic.folia.xml
@@ -1,0 +1,86 @@
+<?xml version='1.0' encoding='utf-8'?>
+<FoLiA xmlns="http://ilk.uvt.nl/folia" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="Xar" version="2.2.1" generator="foliapy-v2.2.5">
+  <metadata type="native">
+    <annotations>
+      <token-annotation annotator="proycon" annotatortype="manual"/>
+      <phonological-annotation set="adhoc" annotator="proycon" annotatortype="manual"/>
+      <morphological-annotation set="adhoc" annotator="proycon" annotatortype="manual"/>
+      <pos-annotation set="adhoc" annotator="proycon" annotatortype="manual"/>
+      <entity-annotation set="https://raw.githubusercontent.com/proycon/folia/master/setdefinitions/namedentities.foliaset.xml" annotator="proycon" annotatortype="manual"/>
+      <text-annotation set="https://raw.githubusercontent.com/proycon/folia/master/setdefinitions/text.foliaset.ttl"/>
+      <sentence-annotation/>
+      <paragraph-annotation/>
+      <division-annotation/>
+      <head-annotation/>
+      <phon-annotation set="https://raw.githubusercontent.com/proycon/folia/master/setdefinitions/phon.foliaset.ttl"/>
+    </annotations>
+    <provenance>
+      <processor xml:id="p1" name="proycon" type="manual"/>
+      <processor xml:id="proc.foliavalidator.2afc0a70" name="foliavalidator" type="auto" version="2.2.7" folia_version="2.2.1" command="foliavalidator -o tmp" host="mhysa.anaproy.nl" user="proycon" begindatetime="2020-04-29T23:38:16" src="https://github.com/proycon/foliatools">
+        <meta id="valid">yes</meta>
+        <processor xml:id="proc.foliavalidator.2afc0a70.generator" name="foliapy" type="generator" version="2.2.5" folia_version="2.2.1" src="https://github.com/proycon/foliapy"/>
+      </processor>
+    </provenance>
+    <meta id="language">ar</meta>
+    <meta id="direction">rtl</meta>
+  </metadata>
+  <text xml:id="Xar.text">
+    <div xml:id="Xar.div">
+      <head xml:id="Xar.text.head">
+        <t>من أنا؟</t>
+      </head>
+      <p xml:id="Xar.p.1">
+        <s xml:id="Xar.p.1.s.1">
+          <t>اسمي مارتن.</t>
+          <w xml:id="Xar.p.1.s.1.w.1">
+            <t offset="0">اسمي</t>
+            <ph>ismī</ph>
+            <pos class="noun_compound"/>
+            <morphology>
+              <morpheme class="stem" function="lexical">
+                <t offset="0">اسم</t>
+                <pos class="noun"/>
+              </morpheme>
+              <morpheme class="suffix" function="inflectional">
+                <t offset="3">ي</t>
+                <pos class="possessive_marker"/>
+              </morpheme>
+            </morphology>
+          </w>
+          <w xml:id="Xar.p.1.s.1.w.2" space="no">
+            <t offset="5">مارتن</t>
+            <ph>mārtin</ph>
+            <pos class="noun_proper"/>
+          </w>
+          <w xml:id="Xar.p.1.s.1.w.3">
+            <t offset="10">.</t>
+            <pos class="punctuation"/>
+          </w>
+          <entities>
+            <entity xml:id="Xar.entity.1" class="per">
+              <wref id="Xar.p.1.s.1.w.2" t="مارتن"/>
+            </entity>
+          </entities>
+        </s>
+        <s xml:id="Xar.p.1.s.2">
+          <t>أنا هولندي.</t>
+          <w xml:id="Xar.p.1.s.2.w.1">
+            <t offset="0">أنا</t>
+            <ph>anā</ph>
+            <pos class="pronoun_personal"/>
+          </w>
+          <w xml:id="Xar.p.1.s.2.w.2" space="no">
+            <t offset="4">هولندي</t>
+            <ph>hūlandī</ph>
+            <pos class="adjective"/>
+          </w>
+          <w xml:id="Xar.p.1.s.2.w.3">
+            <t offset="10">.</t>
+            <pos class="punctuation"/>
+          </w>
+        </s>
+      </p>
+    </div>
+  </text>
+</FoLiA>
+


### PR DESCRIPTION
I implemented a first version of the FoLiA profiler (+tests):

* FoLiA documents get the MIME-type ``application/xml+folia`` as per RFC3023 (though alternatively``text/xml+folia`` can be accepted as equal too)
* The FoLiA version is made available in the ``version`` feature.
* The [declarations of annotation types and sets](https://folia.readthedocs.io/en/latest/metadata.html#annotation-declarations) from the FoLiA document are made available as features to the profiler, the feature name is equal to the element name used in the declaration, so you get features like ``token-annotation``, ``text-annotation``, ``dependency-annotation`` etc etc.. The **value** of this feature is a comma-separated list of sets (which are typically URLs to set definitions), or in case of a set-less annotation type, simply an empty value ("")
* FoLiA documents may reference external metadata files (e.g. CMDI), the URL/path and type are available to the profiler as ``externalMetadata`` and ``externalMetadataType``, respectively. These are however not retrieved or parsed in any way currently. So if crucial metadata (like language) is only in external metadata files, it is not available to the profiler yet. 
* No support yet for inline metadata in foreign formats (simply ignored).
* Provenance data in the FoLiA (v2.0+) is parsed, but only a small portion is made available to the profiler, in the form of a list (squashed tree) of tool names through which the document has successively passed. This is stored in the feature ``provenance``.
* All metadata in FoLiA's native metadata block is made available to the profiler as features; the language field is handled separately. However, FoLiA's native metadata is a simple key-value store and not a controlled vocabulary. The system does some simple guesses to detect iso-639-1/3 language codes in the metadata (field "language" or  "lang").
* The profiler will throw a ProfilerException in case of blatantly invalid FoLiA, but this is by no means a proper validation.

