### PR TITLE
Update tika to 1.28.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,13 +72,13 @@
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-core</artifactId>
-            <version>1.24</version>
+            <version>1.28.5</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-parsers</artifactId>
-            <version>1.24</version>
+            <version>1.28.5</version>
             <scope>compile</scope>
         </dependency>
 


### PR DESCRIPTION
Fixes CVE-2022-46364 - https://www.cve.org/CVERecord?id=CVE-2022-46364
Introduced via:
`eu.clarin.switchboard:profiler@1.0.11 › org.apache.tika:tika-parsers@1.24 › org.apache.cxf:cxf-rt-rs-client@3.3.5`

I am not sure if tika can actually be upgraded to `2.6.0`. So here is a PR for the latest 1.x.x tika